### PR TITLE
Update data folder synID

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,7 @@ profiles {
   pegs_challenge_validate {
     params.project_name = "PEGS DREAM Challenge"
     params.view_id = "syn57373526"
-    params.data_folder_id = "syn59063540"
+    params.data_folder_id = "syn61464987"
     params.goldstandard_id = "syn58734682"
     params.private_folders = "predictions"
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/pegs-evaluation:latest"


### PR DESCRIPTION
## Changelog
* Update the data folder synID, so that it points to a folder of folders.

---

## Additional Context

This change is needed because for the leaderboard round, "both training (_train.) and validation data (_val.) are mounted in the Docker container under `/input/`."  With our current configuration, only the validation data is mounted.  I have since created a new folder called "leaderboard_data" (synID: syn61464987) and have updated the `data_folder_id` parameter for the pegs_challenge_validate profile accordingly.  

I'm not sure yet whether we will need to do a similar update for the test profile -- will check with @gaiaandreoletti once she's back in the office.